### PR TITLE
Include redirect_map helper in the generic table definition

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -51,6 +51,7 @@ struct _name##_table_t { \
   void (*call) (void *, int index); \
   void (*increment) (_key_type, ...); \
   int (*get_stackid) (void *, u64); \
+  u64 (*redirect_map) (int, int); \
   u32 max_entries; \
   int flags; \
 }; \


### PR DESCRIPTION
This change is required to use the `redirect_map` helper in the `DEVMAP` table.
In Polycube, the table has to be shared across multiple eBPF programs but this is not possible in the standard version of BCC.

This is a sort of workaround to allow shared devmaps to use the `redirect_map` helper without having to modify the devmap table definition.