### PR TITLE
New public method getTableDescription() in BPBTableBase class

### DIFF
--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -64,6 +64,10 @@ class BPFTableBase {
     return rc;
   }
 
+  const TableDesc &getTableDescription() {
+      return desc;
+  }
+
  protected:
   explicit BPFTableBase(const TableDesc& desc) : desc(desc) {}
 


### PR DESCRIPTION
This method let returns a duplicate of the protected `TableDesc &desc` object in order to let the BaseCube access to the info related to a BPF table