### PR TITLE
New method getTableDescription() in BPBTableBase class

### DIFF
--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -65,6 +65,10 @@ class BPFTableBase {
     return rc;
   }
 
+  const TableDesc &getTableDescription() {
+      return desc;
+  }
+
  protected:
   explicit BPFTableBase(const TableDesc& desc) : desc(desc) {}
 


### PR DESCRIPTION
This method returns a const reference of the protected `TableDesc &desc` object in order to let the BaseCube access to the info related to a BPF table.

 Note: replaces [PR #2 ](https://github.com/polycube-network/bcc/pull/2)  erroneously done on master