### PR TITLE
Revert "New public method getTableDescription() in BPBTableBase class"

### DIFF
--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -64,10 +64,6 @@ class BPFTableBase {
     return rc;
   }
 
-  const TableDesc &getTableDescription() {
-      return desc;
-  }
-
  protected:
   explicit BPFTableBase(const TableDesc& desc) : desc(desc) {}
 


### PR DESCRIPTION
Reverts polycube-network/bcc#2
This PR was applied to the wrong branch (master instead of polycube)