### PR TITLE
Modified libbpf submodule clone method

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/cc/libbpf"]
 	path = src/cc/libbpf
-	url = git@github.com:libbpf/libbpf.git
+	url = https://github.com/libbpf/libbpf.git


### PR DESCRIPTION
In this PR the submodule libbpf is restored to be clone through https instead of ssh.
This allows both new Polycube consumers and whoever clones this library to
work even though he does not have access to github using rsa keys

Signed-off-by: Simone Magnani <simonemagnani.96@gmail.com>