### PR TITLE
Removing forced path in bcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,6 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "path to install" FORCE)
-endif()
-
 enable_testing()
 
 # populate submodules (libbpf)


### PR DESCRIPTION
This PR aims to remove a forced path in the CMakeList.txt which leads to a wrong Polycube installation

Signed-off-by: Simone Magnani <simonemagnani.96@gmail.com>